### PR TITLE
Proposal for update to guidelines

### DIFF
--- a/guidelines/guidelines.php
+++ b/guidelines/guidelines.php
@@ -30,7 +30,15 @@ $this->title = Yii::t('app', 'Guidelines');
         You may not list servers which serve for the sole purpose of redirecting or advertising other servers or have no content (To our discretion).
     </li>
     <li>
-        You may not reward, harass or force users to interact with our service (e.g. bumping or reviewing a server).
+        You may not reward, harass or force users to interact with our service (e.g. bumping or reviewing a server). Provided below as a courtesy is a non-exhaustive list of examples of rewards that are not permitted:
+        <ul>
+            <li>XP (or other forms of virtual payment)</li>
+            <li>Any form of non-virtual payment</li>
+            <li>Leaderboards (or other forms of explicit tracking of users' actions on our service)</li>
+            <li>Roles (or other benefits over users not interacting with our service)</li>
+            <li>Gifts (e.g. Nitro)</li>
+            <li>Incentives (e.g. entry into a raffle)</li>
+        </ul>
     </li>
     <li>
         You may not use multiple Discord accounts to submit multiple reviews on a server.

--- a/guidelines/guidelines.php
+++ b/guidelines/guidelines.php
@@ -15,28 +15,28 @@ $this->title = Yii::t('app', 'Guidelines');
 </p>
 <ul>
     <li>
-        The use of swear words, dirty words or NSFW (sexual content) to our discretion in a server's meta (title, description and picture), review or other content that may be seen by other users in DISBOARD is not allowed. This will lead to the removal of the content, however, you'll be able to repost the content with a proper language.
+        The use of swear words, dirty words or NSFW (sexual content) to our discretion in a server's meta (title, description and picture), review or other content that may be seen by other users on the DISBOARD site is not allowed. This will lead to the removal of the content, however, you'll be able to repost the content with appropriate meta.
     </li>
     <li>
         You may not violate any laws or regulations in your country of residence or promote the violation of them.
     </li>
     <li>
-        Servers violating <a href="https://discordapp.com/guidelines" target="_blank">Discord Community Guidelines</a> are not allowed.
+        Servers in violation of the <a href="https://discordapp.com/guidelines" target="_blank">Discord Community Guidelines</a> are not allowed.
     </li>
     <li>
-        The use of bots or other scripts to automatically do actions in DISBOARD such as bumping a server ("auto-bump") is not allowed. Bumping, creating reviews and etc. must be done manually.
+        The use of bots or other scripts to perform actions on our service such as bumping a server ("auto-bump") is not allowed. Bumping, creating reviews and other actions must be done manually.
     </li>
     <li>
         You may not list servers which serve for the sole purpose of redirecting or advertising other servers or have no content (To our discretion).
     </li>
     <li>
-        You may not reward or force users to do actions in DISBOARD. For instance, you may not reward your users for posting a nice review on a server or force them to bump a server.
+        You may not reward, harass or force users to interact with our service (e.g. bumping or reviewing a server).
     </li>
     <li>
-        You may not create multiple Discord accounts to submit multiple reviews. Please just post 1 review per person.
+        You may not use multiple Discord accounts to submit multiple reviews on a server.
     </li>
     <li>
-        All servers which are mainly based on NSFW (sexual content to our discretion) must be marked as "NSFW" in DISBOARD.
+        All servers which are mainly based on NSFW (sexual content to our discretion) must be marked as "NSFW" on the DISBOARD site.
     </li>
 </ul>
 

--- a/guidelines/guidelines.php
+++ b/guidelines/guidelines.php
@@ -30,7 +30,7 @@ $this->title = Yii::t('app', 'Guidelines');
         You may not list servers which serve for the sole purpose of redirecting or advertising other servers or have no content (To our discretion).
     </li>
     <li>
-        You may not reward, harass or force users to interact with our service (e.g. bumping or reviewing a server). Provided below as a courtesy is a non-exhaustive list of examples of rewards that are not permitted:
+        You may not reward, harass or force users to interact with our service (e.g. bumping or reviewing a server), including but not limited to:
         <ul>
             <li>XP (or other forms of virtual payment)</li>
             <li>Any form of non-virtual payment</li>

--- a/guidelines/guidelines.php
+++ b/guidelines/guidelines.php
@@ -7,7 +7,7 @@ $this->title = Yii::t('app', 'Guidelines');
     <?= $this->title ?>
 </h1>
 <p class="has-text-right is-italic">
-    Last Modified: 2020-04-10
+    Last Modified: 2021-01-06
 </p>
 <p>
     In order to keep a safe community, there are some guidelines which need to be followed by you <br>

--- a/guidelines/guidelines.php
+++ b/guidelines/guidelines.php
@@ -7,7 +7,7 @@ $this->title = Yii::t('app', 'Guidelines');
     <?= $this->title ?>
 </h1>
 <p class="has-text-right is-italic">
-    Last Modified: 2021-01-06
+    Last Modified: 6th of January, 2021
 </p>
 <p>
     In order to keep a safe community, there are some guidelines which need to be followed by you <br>


### PR DESCRIPTION
This is a proposal for an updated set of guidelines that uses more explicit language and examples to make it easier for users to understand what is allowed and what is not allowed.

This includes:
- explicit referral to the service as a whole or the site instead of `in DISBOARD` which could be misunderstood as the site only.
- a non-exhaustive list of examples as to what are classed as rewards
- improved grammar and phrasing for the guidelines (for example, the first bullet point originally mentioned allowing servers to be unbanned so long as they use `proper language` in their listing, which may lead to confusion for removals due to icons)

The aim of this update is to make the guidelines **easier to understand and more explicit**, whilst still maintaining their meaning so any feedback/criticisms would be greatly appreciated!