### PR TITLE
chore: impl locale keys for new features

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -82,7 +82,7 @@
 		"latency": "`Shard latency`: {{ shardLatency }}ms"
 	},
 	"moderator": {
-		"is": "{{ user }} is a moderator of the DISBOARD service.",
-		"not": "{{ user }} is not a moderator of the DISBOARD service."
+		"is": "{{ user }} is a moderator of DISBOARD.",
+		"not": "{{ user }} is not a moderator of DISBOARD."
 	}
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -34,6 +34,7 @@
 		"adminOnly": "This command can only be run by administrators.",
 		"invalidChannel": "Invalid channel: {{ input }}\nTry mentioning a channel, for example: {{ exampleChannel }}.",
 		"invalidChannelType": "I can only create an invite in:\n• A regular text channel.\n• An announcement channel.\n\nPlease specify one of the above channel types to create an invite in.",
+		"invalidMention": "Invalid mention.",
 		"handlingCommand": "I'm handling your command!",
 		"api": {
 			"down": "The DISBOARD API appears to be down! :sob:\nPlease try again later.",
@@ -63,7 +64,12 @@
 			"notFound": {
 				"embed": "This server has not been added to DISBOARD yet.\n*Are you an admin? Add this server via the [dashboard]({{ dashboardLink }}).*",
 				"text": "This server has not been added to DISBOARD yet.\n*Are you an admin? Add this server via the dashboard at <{{ dashboardLink }}>.*"
+			},
+			"invalidInvite": {
+				"admin": "Your server doesn't have a valid invite set. Run {{ command }} to set the invite and then re-run the command.",
+				"member": "This server doesn't have a valid invite set. Ask an admin to run {{ command }} to set the invite and then re-run the command."
 			}
+
 		}
 	},
 	"debug": {
@@ -74,5 +80,9 @@
 		"main": "`Main language`: `{{ langCode }}`",
 		"default": "`Default channel`: {{ defaultChannel }}",
 		"latency": "`Shard latency`: {{ shardLatency }}ms"
+	},
+	"moderator": {
+		"is": "{{ user }} is a moderator of the DISBOARD service.",
+		"not": "{{ user }} is not a moderator of the DISBOARD service."
 	}
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -33,7 +33,6 @@
 		"generic": "Une erreur inconnue s'est produite.\n\nTu peux relancer la commande de nouveau. Si l'erreur persiste, fais-le nous savoir sur le serveur de support (<{{ supportServerInvite }}>).\n\nRéférence : `{{ errorId }}`",
 		"adminOnly": "Cette commande ne peut être utilisée que par les administrateurs.",
 		"invalidChannel": "Salon invalide : {{ input }}\nRessaie en mentionnant un salon ; par exemple : {{ exampleChannel }}.",
-		"invalidChannelType": "I can only create an invite in:\n• A regular text channel.\n• An announcement channel.\n\nPlease specify one of the above channel types to create an invite in.",
 		"invalidChannelType": "Je ne peux créer une invitation que :\n• Dans un salon textuel régulier\n• Dans un salon d'annonces\n\nSpécifie un des types de salon ci-dessus pour créer une invitation dessus.",
 		"handlingCommand": "Je m'occupe de ta commande !",
 		"api": {


### PR DESCRIPTION
This PR adds some new keys for some improved UX.

If a key is not found in the locale's json file, it will default to the english json file. This change is not breaking for the bot.

This also removes a duplicate key in the `fr.json` file.